### PR TITLE
Index Ethereum hub bridge activity

### DIFF
--- a/abis/EvmWormholeL1BitcoinDepositor.json
+++ b/abis/EvmWormholeL1BitcoinDepositor.json
@@ -1,0 +1,89 @@
+[
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "depositKey",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "destinationChainDepositOwner",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "l1Sender",
+        "type": "address"
+      }
+    ],
+    "name": "DepositInitialized",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "depositKey",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "destinationChainDepositOwner",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "l1Sender",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "initialAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "tbtcAmount",
+        "type": "uint256"
+      }
+    ],
+    "name": "DepositFinalized",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "l2Receiver",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "transferSequence",
+        "type": "uint64"
+      }
+    ],
+    "name": "TokensTransferredWithPayload",
+    "type": "event"
+  }
+]

--- a/abis/L1BitcoinRedeemer.json
+++ b/abis/L1BitcoinRedeemer.json
@@ -1,0 +1,56 @@
+[
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "redemptionKey",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes20",
+        "name": "walletPubKeyHash",
+        "type": "bytes20"
+      },
+      {
+        "components": [
+          {
+            "internalType": "bytes32",
+            "name": "txHash",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "uint32",
+            "name": "txOutputIndex",
+            "type": "uint32"
+          },
+          {
+            "internalType": "uint64",
+            "name": "txOutputValue",
+            "type": "uint64"
+          }
+        ],
+        "indexed": false,
+        "internalType": "struct BitcoinTx.UTXO",
+        "name": "mainUtxo",
+        "type": "tuple"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes",
+        "name": "redemptionOutputScript",
+        "type": "bytes"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "RedemptionRequested",
+    "type": "event"
+  }
+]

--- a/abis/NonEvmWormholeL1BitcoinDepositor.json
+++ b/abis/NonEvmWormholeL1BitcoinDepositor.json
@@ -1,0 +1,89 @@
+[
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "depositKey",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "destinationChainDepositOwner",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "l1Sender",
+        "type": "address"
+      }
+    ],
+    "name": "DepositInitialized",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "depositKey",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "destinationChainDepositOwner",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "l1Sender",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "initialAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "tbtcAmount",
+        "type": "uint256"
+      }
+    ],
+    "name": "DepositFinalized",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "destinationChainReceiver",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "transferSequence",
+        "type": "uint64"
+      }
+    ],
+    "name": "TokensTransferredWithPayload",
+    "type": "event"
+  }
+]

--- a/abis/StarkNetBitcoinDepositor.json
+++ b/abis/StarkNetBitcoinDepositor.json
@@ -1,0 +1,95 @@
+[
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "depositKey",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "destinationChainDepositOwner",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "l1Sender",
+        "type": "address"
+      }
+    ],
+    "name": "DepositInitialized",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "depositKey",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "destinationChainDepositOwner",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "l1Sender",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "initialAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "tbtcAmount",
+        "type": "uint256"
+      }
+    ],
+    "name": "DepositFinalized",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "starkNetRecipient",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "fee",
+        "type": "uint256"
+      }
+    ],
+    "name": "TBTCBridgedToStarkNet",
+    "type": "event"
+  }
+]

--- a/networks.json
+++ b/networks.json
@@ -31,6 +31,30 @@
     "RedemptionWatchtower": {
       "address": "0x4E6CFb556143381070b17825707b3DE7F3148FaC",
       "startBlock": 5340873
+    },
+    "ArbitrumL1BitcoinDepositor": {
+      "address": "0xD9B523fb879C63b00ef14e48C98f4e3398d3BA2D",
+      "startBlock": 6281003
+    },
+    "BaseL1BitcoinDepositor": {
+      "address": "0x59FAE614867b66421b44D1Ed3461e6B6a4B50106",
+      "startBlock": 7592526
+    },
+    "SolanaL1BitcoinDepositor": {
+      "address": "0x02339D3c0fD0881aa59EF61E3ef6B8f8103edA1d",
+      "startBlock": 8088729
+    },
+    "SuiBTCDepositorWormhole": {
+      "address": "0x25b614064293A6B9012E82Bb31BC2B1Be34e36Cb",
+      "startBlock": 8680336
+    },
+    "StarkNetBitcoinDepositor": {
+      "address": "0x40c74a5f0b0e6CC3Ae4E8dD2Db46d372504445DA",
+      "startBlock": 8509896
+    },
+    "L1BitcoinRedeemer": {
+      "address": "0xe8312BD306512c5CAD4D650df373D5597B1C697A",
+      "startBlock": 8558171
     }
   },
   "mainnet": {
@@ -65,6 +89,30 @@
     "RedemptionWatchtower": {
       "address": "0xB8dF0A949aC45ff8f401553A1dcb742Feb38E6D3",
       "startBlock": 19413942
+    },
+    "ArbitrumL1BitcoinDepositor": {
+      "address": "0x75A6e4A7C8fAa162192FAD6C1F7A6d48992c619A",
+      "startBlock": 20632547
+    },
+    "BaseL1BitcoinDepositor": {
+      "address": "0x186D048097c7406C64EfB0537886E3CaE100a1fe",
+      "startBlock": 21961116
+    },
+    "SolanaL1BitcoinDepositor": {
+      "address": "0x35D6701640fca561BaCfE4151063C8e55aF66dB7",
+      "startBlock": 22385228
+    },
+    "SuiBTCDepositorWormhole": {
+      "address": "0xb810AbD43d8FCFD812d6FEB14fefc236E92a341A",
+      "startBlock": 22842726
+    },
+    "StarkNetBitcoinDepositor": {
+      "address": "0xC9031f76006da0BD4bFa9E02aDf0d448dB3BC155",
+      "startBlock": 22671770
+    },
+    "L1BitcoinRedeemer": {
+      "address": "0x5D4d83aaB53B7E7cA915AEB2d4d3f4e03823DbDe",
+      "startBlock": 23309400
     }
   }
 }

--- a/schema.graphql
+++ b/schema.graphql
@@ -117,6 +117,52 @@ enum TransactionEvent {
     WITHDRAW_REWARD
 }
 
+enum BridgeActivityType {
+    DEPOSIT_INITIALIZED
+    DEPOSIT_FINALIZED
+    TOKENS_TRANSFERRED_WITH_PAYLOAD
+    TBTC_BRIDGED_TO_STARKNET
+    REDEMPTION_REQUESTED
+}
+
+enum BridgeActivityDirection {
+    IN
+    OUT
+}
+
+type BridgeActivity @entity {
+    id: ID!
+    type: BridgeActivityType!
+    direction: BridgeActivityDirection!
+    protocol: String!
+    sourceChain: String!
+    destinationChain: String!
+    sourceContract: Bytes!
+    txHash: Bytes!
+    logIndex: BigInt!
+    blockNumber: BigInt!
+    timestamp: BigInt!
+
+    sender: Bytes
+    recipient: Bytes
+    recipientBytes32: Bytes
+    starkNetRecipient: BigInt
+    walletPubKeyHash: Bytes
+    redemptionOutputScript: Bytes
+
+    depositKey: BigInt
+    redemptionKey: BigInt
+    amount: BigInt
+    initialAmount: BigInt
+    tbtcAmount: BigInt
+    sequence: BigInt
+    fee: BigInt
+
+    mainUtxoTxHash: Bytes
+    mainUtxoOutputIndex: BigInt
+    mainUtxoOutputValue: BigInt
+}
+
 type Event @entity {
     #Hash of transaction
     id: ID!

--- a/src/mappingBridgeActivity.ts
+++ b/src/mappingBridgeActivity.ts
@@ -1,0 +1,347 @@
+import {BigInt, Bytes, ethereum} from "@graphprotocol/graph-ts"
+
+import {
+    DepositFinalized as ArbitrumDepositFinalized,
+    DepositInitialized as ArbitrumDepositInitialized,
+    TokensTransferredWithPayload as ArbitrumTokensTransferredWithPayload
+} from "../generated/ArbitrumL1BitcoinDepositor/EvmWormholeL1BitcoinDepositor"
+import {
+    DepositFinalized as BaseDepositFinalized,
+    DepositInitialized as BaseDepositInitialized,
+    TokensTransferredWithPayload as BaseTokensTransferredWithPayload
+} from "../generated/BaseL1BitcoinDepositor/EvmWormholeL1BitcoinDepositor"
+import {
+    DepositFinalized as SolanaDepositFinalized,
+    DepositInitialized as SolanaDepositInitialized,
+    TokensTransferredWithPayload as SolanaTokensTransferredWithPayload
+} from "../generated/SolanaL1BitcoinDepositor/NonEvmWormholeL1BitcoinDepositor"
+import {
+    DepositFinalized as SuiDepositFinalized,
+    DepositInitialized as SuiDepositInitialized,
+    TokensTransferredWithPayload as SuiTokensTransferredWithPayload
+} from "../generated/SuiBTCDepositorWormhole/NonEvmWormholeL1BitcoinDepositor"
+import {
+    DepositFinalized as StarkNetDepositFinalized,
+    DepositInitialized as StarkNetDepositInitialized,
+    TBTCBridgedToStarkNet
+} from "../generated/StarkNetBitcoinDepositor/StarkNetBitcoinDepositor"
+import {RedemptionRequested} from "../generated/L1BitcoinRedeemer/L1BitcoinRedeemer"
+import {BridgeActivity} from "../generated/schema"
+import {getIDFromEvent} from "./utils/utils"
+
+function createBridgeActivity(
+    event: ethereum.Event,
+    activityType: string,
+    direction: string,
+    protocol: string,
+    sourceChain: string,
+    destinationChain: string
+): BridgeActivity {
+    let activity = new BridgeActivity(getIDFromEvent(event))
+    activity.type = activityType
+    activity.direction = direction
+    activity.protocol = protocol
+    activity.sourceChain = sourceChain
+    activity.destinationChain = destinationChain
+    activity.sourceContract = event.address
+    activity.txHash = event.transaction.hash
+    activity.logIndex = event.logIndex
+    activity.blockNumber = event.block.number
+    activity.timestamp = event.block.timestamp
+
+    return activity
+}
+
+function saveDepositInitialized(
+    event: ethereum.Event,
+    protocol: string,
+    destinationChain: string,
+    depositKey: BigInt,
+    destinationChainDepositOwner: Bytes,
+    l1Sender: Bytes
+): void {
+    let activity = createBridgeActivity(
+        event,
+        "DEPOSIT_INITIALIZED",
+        "IN",
+        protocol,
+        "Bitcoin",
+        destinationChain
+    )
+    activity.depositKey = depositKey
+    activity.recipientBytes32 = destinationChainDepositOwner
+    activity.sender = l1Sender
+    activity.save()
+}
+
+function saveDepositFinalized(
+    event: ethereum.Event,
+    protocol: string,
+    destinationChain: string,
+    depositKey: BigInt,
+    destinationChainDepositOwner: Bytes,
+    l1Sender: Bytes,
+    initialAmount: BigInt,
+    tbtcAmount: BigInt
+): void {
+    let activity = createBridgeActivity(
+        event,
+        "DEPOSIT_FINALIZED",
+        "OUT",
+        protocol,
+        "Ethereum",
+        destinationChain
+    )
+    activity.depositKey = depositKey
+    activity.recipientBytes32 = destinationChainDepositOwner
+    activity.sender = l1Sender
+    activity.initialAmount = initialAmount
+    activity.tbtcAmount = tbtcAmount
+    activity.amount = tbtcAmount
+    activity.save()
+}
+
+function saveEvmWormholeTransfer(
+    event: ethereum.Event,
+    destinationChain: string,
+    amount: BigInt,
+    receiver: Bytes,
+    sequence: BigInt
+): void {
+    let activity = createBridgeActivity(
+        event,
+        "TOKENS_TRANSFERRED_WITH_PAYLOAD",
+        "OUT",
+        "Wormhole",
+        "Ethereum",
+        destinationChain
+    )
+    activity.amount = amount
+    activity.recipient = receiver
+    activity.sequence = sequence
+    activity.save()
+}
+
+function saveNonEvmWormholeTransfer(
+    event: ethereum.Event,
+    destinationChain: string,
+    amount: BigInt,
+    receiver: Bytes,
+    sequence: BigInt
+): void {
+    let activity = createBridgeActivity(
+        event,
+        "TOKENS_TRANSFERRED_WITH_PAYLOAD",
+        "OUT",
+        "Wormhole",
+        "Ethereum",
+        destinationChain
+    )
+    activity.amount = amount
+    activity.recipientBytes32 = receiver
+    activity.sequence = sequence
+    activity.save()
+}
+
+export function handleArbitrumDepositInitialized(event: ArbitrumDepositInitialized): void {
+    saveDepositInitialized(
+        event,
+        "Wormhole",
+        "Arbitrum",
+        event.params.depositKey,
+        event.params.destinationChainDepositOwner,
+        event.params.l1Sender
+    )
+}
+
+export function handleArbitrumDepositFinalized(event: ArbitrumDepositFinalized): void {
+    saveDepositFinalized(
+        event,
+        "Wormhole",
+        "Arbitrum",
+        event.params.depositKey,
+        event.params.destinationChainDepositOwner,
+        event.params.l1Sender,
+        event.params.initialAmount,
+        event.params.tbtcAmount
+    )
+}
+
+export function handleArbitrumTokensTransferredWithPayload(
+    event: ArbitrumTokensTransferredWithPayload
+): void {
+    saveEvmWormholeTransfer(
+        event,
+        "Arbitrum",
+        event.params.amount,
+        event.params.l2Receiver,
+        event.params.transferSequence
+    )
+}
+
+export function handleBaseDepositInitialized(event: BaseDepositInitialized): void {
+    saveDepositInitialized(
+        event,
+        "Wormhole",
+        "Base",
+        event.params.depositKey,
+        event.params.destinationChainDepositOwner,
+        event.params.l1Sender
+    )
+}
+
+export function handleBaseDepositFinalized(event: BaseDepositFinalized): void {
+    saveDepositFinalized(
+        event,
+        "Wormhole",
+        "Base",
+        event.params.depositKey,
+        event.params.destinationChainDepositOwner,
+        event.params.l1Sender,
+        event.params.initialAmount,
+        event.params.tbtcAmount
+    )
+}
+
+export function handleBaseTokensTransferredWithPayload(
+    event: BaseTokensTransferredWithPayload
+): void {
+    saveEvmWormholeTransfer(
+        event,
+        "Base",
+        event.params.amount,
+        event.params.l2Receiver,
+        event.params.transferSequence
+    )
+}
+
+export function handleSolanaDepositInitialized(event: SolanaDepositInitialized): void {
+    saveDepositInitialized(
+        event,
+        "Wormhole",
+        "Solana",
+        event.params.depositKey,
+        event.params.destinationChainDepositOwner,
+        event.params.l1Sender
+    )
+}
+
+export function handleSolanaDepositFinalized(event: SolanaDepositFinalized): void {
+    saveDepositFinalized(
+        event,
+        "Wormhole",
+        "Solana",
+        event.params.depositKey,
+        event.params.destinationChainDepositOwner,
+        event.params.l1Sender,
+        event.params.initialAmount,
+        event.params.tbtcAmount
+    )
+}
+
+export function handleSolanaTokensTransferredWithPayload(
+    event: SolanaTokensTransferredWithPayload
+): void {
+    saveNonEvmWormholeTransfer(
+        event,
+        "Solana",
+        event.params.amount,
+        event.params.destinationChainReceiver,
+        event.params.transferSequence
+    )
+}
+
+export function handleSuiDepositInitialized(event: SuiDepositInitialized): void {
+    saveDepositInitialized(
+        event,
+        "Wormhole",
+        "Sui",
+        event.params.depositKey,
+        event.params.destinationChainDepositOwner,
+        event.params.l1Sender
+    )
+}
+
+export function handleSuiDepositFinalized(event: SuiDepositFinalized): void {
+    saveDepositFinalized(
+        event,
+        "Wormhole",
+        "Sui",
+        event.params.depositKey,
+        event.params.destinationChainDepositOwner,
+        event.params.l1Sender,
+        event.params.initialAmount,
+        event.params.tbtcAmount
+    )
+}
+
+export function handleSuiTokensTransferredWithPayload(
+    event: SuiTokensTransferredWithPayload
+): void {
+    saveNonEvmWormholeTransfer(
+        event,
+        "Sui",
+        event.params.amount,
+        event.params.destinationChainReceiver,
+        event.params.transferSequence
+    )
+}
+
+export function handleStarkNetDepositInitialized(event: StarkNetDepositInitialized): void {
+    saveDepositInitialized(
+        event,
+        "StarkGate",
+        "StarkNet",
+        event.params.depositKey,
+        event.params.destinationChainDepositOwner,
+        event.params.l1Sender
+    )
+}
+
+export function handleStarkNetDepositFinalized(event: StarkNetDepositFinalized): void {
+    saveDepositFinalized(
+        event,
+        "StarkGate",
+        "StarkNet",
+        event.params.depositKey,
+        event.params.destinationChainDepositOwner,
+        event.params.l1Sender,
+        event.params.initialAmount,
+        event.params.tbtcAmount
+    )
+}
+
+export function handleTBTCBridgedToStarkNet(event: TBTCBridgedToStarkNet): void {
+    let activity = createBridgeActivity(
+        event,
+        "TBTC_BRIDGED_TO_STARKNET",
+        "OUT",
+        "StarkGate",
+        "Ethereum",
+        "StarkNet"
+    )
+    activity.sender = event.params.sender
+    activity.amount = event.params.amount
+    activity.starkNetRecipient = event.params.starkNetRecipient
+    activity.fee = event.params.fee
+    activity.save()
+}
+
+export function handleRedemptionRequested(event: RedemptionRequested): void {
+    let activity = createBridgeActivity(
+        event,
+        "REDEMPTION_REQUESTED",
+        "IN",
+        "Wormhole",
+        "Unknown",
+        "Bitcoin"
+    )
+    activity.redemptionKey = event.params.redemptionKey
+    activity.walletPubKeyHash = event.params.walletPubKeyHash
+    activity.redemptionOutputScript = event.params.redemptionOutputScript
+    activity.amount = event.params.amount
+    activity.mainUtxoTxHash = event.params.mainUtxo.txHash
+    activity.mainUtxoOutputIndex = event.params.mainUtxo.txOutputIndex
+    activity.mainUtxoOutputValue = event.params.mainUtxo.txOutputValue
+    activity.save()
+}

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -367,3 +367,149 @@ dataSources:
         - event: Unbanned(indexed address)
           handler: handleUnbanned
       file: ./src/mappingRedemptionWatchtower.ts
+  - kind: ethereum
+    name: ArbitrumL1BitcoinDepositor
+    network: mainnet
+    source:
+      abi: EvmWormholeL1BitcoinDepositor
+      address: "0x75A6e4A7C8fAa162192FAD6C1F7A6d48992c619A"
+      startBlock: 20632547
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.6
+      language: wasm/assemblyscript
+      entities:
+        - BridgeActivity
+      abis:
+        - name: EvmWormholeL1BitcoinDepositor
+          file: ./abis/EvmWormholeL1BitcoinDepositor.json
+      eventHandlers:
+        - event: DepositInitialized(indexed uint256,indexed bytes32,indexed address)
+          handler: handleArbitrumDepositInitialized
+        - event: DepositFinalized(indexed uint256,indexed bytes32,indexed
+            address,uint256,uint256)
+          handler: handleArbitrumDepositFinalized
+        - event: TokensTransferredWithPayload(uint256,address,uint64)
+          handler: handleArbitrumTokensTransferredWithPayload
+      file: ./src/mappingBridgeActivity.ts
+  - kind: ethereum
+    name: BaseL1BitcoinDepositor
+    network: mainnet
+    source:
+      abi: EvmWormholeL1BitcoinDepositor
+      address: "0x186D048097c7406C64EfB0537886E3CaE100a1fe"
+      startBlock: 21961116
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.6
+      language: wasm/assemblyscript
+      entities:
+        - BridgeActivity
+      abis:
+        - name: EvmWormholeL1BitcoinDepositor
+          file: ./abis/EvmWormholeL1BitcoinDepositor.json
+      eventHandlers:
+        - event: DepositInitialized(indexed uint256,indexed bytes32,indexed address)
+          handler: handleBaseDepositInitialized
+        - event: DepositFinalized(indexed uint256,indexed bytes32,indexed
+            address,uint256,uint256)
+          handler: handleBaseDepositFinalized
+        - event: TokensTransferredWithPayload(uint256,address,uint64)
+          handler: handleBaseTokensTransferredWithPayload
+      file: ./src/mappingBridgeActivity.ts
+  - kind: ethereum
+    name: SolanaL1BitcoinDepositor
+    network: mainnet
+    source:
+      abi: NonEvmWormholeL1BitcoinDepositor
+      address: "0x35D6701640fca561BaCfE4151063C8e55aF66dB7"
+      startBlock: 22385228
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.6
+      language: wasm/assemblyscript
+      entities:
+        - BridgeActivity
+      abis:
+        - name: NonEvmWormholeL1BitcoinDepositor
+          file: ./abis/NonEvmWormholeL1BitcoinDepositor.json
+      eventHandlers:
+        - event: DepositInitialized(indexed uint256,indexed bytes32,indexed address)
+          handler: handleSolanaDepositInitialized
+        - event: DepositFinalized(indexed uint256,indexed bytes32,indexed
+            address,uint256,uint256)
+          handler: handleSolanaDepositFinalized
+        - event: TokensTransferredWithPayload(uint256,bytes32,uint64)
+          handler: handleSolanaTokensTransferredWithPayload
+      file: ./src/mappingBridgeActivity.ts
+  - kind: ethereum
+    name: SuiBTCDepositorWormhole
+    network: mainnet
+    source:
+      abi: NonEvmWormholeL1BitcoinDepositor
+      address: "0xb810AbD43d8FCFD812d6FEB14fefc236E92a341A"
+      startBlock: 22842726
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.6
+      language: wasm/assemblyscript
+      entities:
+        - BridgeActivity
+      abis:
+        - name: NonEvmWormholeL1BitcoinDepositor
+          file: ./abis/NonEvmWormholeL1BitcoinDepositor.json
+      eventHandlers:
+        - event: DepositInitialized(indexed uint256,indexed bytes32,indexed address)
+          handler: handleSuiDepositInitialized
+        - event: DepositFinalized(indexed uint256,indexed bytes32,indexed
+            address,uint256,uint256)
+          handler: handleSuiDepositFinalized
+        - event: TokensTransferredWithPayload(uint256,bytes32,uint64)
+          handler: handleSuiTokensTransferredWithPayload
+      file: ./src/mappingBridgeActivity.ts
+  - kind: ethereum
+    name: StarkNetBitcoinDepositor
+    network: mainnet
+    source:
+      abi: StarkNetBitcoinDepositor
+      address: "0xC9031f76006da0BD4bFa9E02aDf0d448dB3BC155"
+      startBlock: 22671770
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.6
+      language: wasm/assemblyscript
+      entities:
+        - BridgeActivity
+      abis:
+        - name: StarkNetBitcoinDepositor
+          file: ./abis/StarkNetBitcoinDepositor.json
+      eventHandlers:
+        - event: DepositInitialized(indexed uint256,indexed bytes32,indexed address)
+          handler: handleStarkNetDepositInitialized
+        - event: DepositFinalized(indexed uint256,indexed bytes32,indexed
+            address,uint256,uint256)
+          handler: handleStarkNetDepositFinalized
+        - event: TBTCBridgedToStarkNet(indexed address,uint256,uint256,uint256)
+          handler: handleTBTCBridgedToStarkNet
+      file: ./src/mappingBridgeActivity.ts
+  - kind: ethereum
+    name: L1BitcoinRedeemer
+    network: mainnet
+    source:
+      abi: L1BitcoinRedeemer
+      address: "0x5D4d83aaB53B7E7cA915AEB2d4d3f4e03823DbDe"
+      startBlock: 23309400
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.6
+      language: wasm/assemblyscript
+      entities:
+        - BridgeActivity
+      abis:
+        - name: L1BitcoinRedeemer
+          file: ./abis/L1BitcoinRedeemer.json
+      eventHandlers:
+        - event: RedemptionRequested(indexed uint256,indexed
+            bytes20,(bytes32,uint32,uint64),indexed bytes,uint256)
+          handler: handleRedemptionRequested
+      file: ./src/mappingBridgeActivity.ts


### PR DESCRIPTION
## Summary
- add a normalized `BridgeActivity` entity for Ethereum hub-side bridge lifecycle events
- index Arbitrum, Base, Solana, Sui, StarkNet depositor events plus the L1 Bitcoin redeemer event on mainnet and Sepolia
- add minimal ABI fragments and network overrides for those deployed hub contracts

Sei is intentionally excluded from this PR.

## Notes
- `DepositInitialized` / `DepositFinalized` / transfer events are captured from the Ethereum hub contracts only; destination-chain follow-up activity is out of scope.
- `L1BitcoinRedeemer` records inbound/redemption hub activity, but the event does not expose the originating spoke chain, so the mapping stores `sourceChain` as `Unknown`.
- The mainnet `L1BitcoinRedeemer` artifact has a stale Sepolia receipt; its mainnet start block was set from the mainnet creation tx `0x61fe2dd347dbc079226f9264bd10b2ab434155caad5e0bc480d0380a78ba8e22` at block `23309400`.

## Verification
- `npm run codegen`
- `npm run build-mainnet`
- `npm run build-sepolia`